### PR TITLE
Allow connections via SSH agent

### DIFF
--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -64,13 +64,13 @@ Required:
 
 Optional:
 
+- **agent** (Boolean) Use a local SSH agent to login to the remote host. Defaults to `false`.
 - **password** (String, Sensitive) The pasword for the user on the remote host.
 - **port** (Number) The ssh port on the remote host. Defaults to `22`.
 - **private_key** (String, Sensitive) The private key used to login to the remote host.
 - **private_key_env_var** (String) The name of the local environment variable containing the private key used to login to the remote host.
 - **private_key_path** (String) The local path to the private key used to login to the remote host.
 - **sudo** (Boolean) Use sudo to gain access to file. Defaults to `false`.
-- **agent** (Booean) Use local SSH agent to login to the remote host. Default to `false`.
 
 
 <a id="nestedatt--result_conn"></a>
@@ -78,6 +78,7 @@ Optional:
 
 Read-Only:
 
+- **agent** (Boolean)
 - **host** (String)
 - **password** (String)
 - **port** (Number)
@@ -86,5 +87,5 @@ Read-Only:
 - **private_key_path** (String)
 - **sudo** (Boolean)
 - **user** (String)
-- **agent** (Booean)
+
 

--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -70,6 +70,7 @@ Optional:
 - **private_key_env_var** (String) The name of the local environment variable containing the private key used to login to the remote host.
 - **private_key_path** (String) The local path to the private key used to login to the remote host.
 - **sudo** (Boolean) Use sudo to gain access to file. Defaults to `false`.
+- **agent** (Booean) Use local SSH agent to login to the remote host. Default to `false`.
 
 
 <a id="nestedatt--result_conn"></a>
@@ -85,5 +86,5 @@ Read-Only:
 - **private_key_path** (String)
 - **sudo** (Boolean)
 - **user** (String)
-
+- **agent** (Booean)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,3 +71,4 @@ Optional:
 - **private_key_env_var** (String) The name of the local environment variable containing the private key used to login to the remote host.
 - **private_key_path** (String) The local path to the private key used to login to the remote host.
 - **sudo** (Boolean) Use sudo to gain access to file. Defaults to `false`.
+- **agent** (Booean) Use local SSH agent to login to the remote host. Default to `false`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,10 +65,10 @@ Required:
 
 Optional:
 
+- **agent** (Boolean) Use a local SSH agent to login to the remote host. Defaults to `false`.
 - **password** (String, Sensitive) The pasword for the user on the remote host.
 - **port** (Number) The ssh port on the remote host. Defaults to `22`.
 - **private_key** (String, Sensitive) The private key used to login to the remote host.
 - **private_key_env_var** (String) The name of the local environment variable containing the private key used to login to the remote host.
 - **private_key_path** (String) The local path to the private key used to login to the remote host.
 - **sudo** (Boolean) Use sudo to gain access to file. Defaults to `false`.
-- **agent** (Booean) Use local SSH agent to login to the remote host. Default to `false`.

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -71,6 +71,7 @@ Required:
 
 Optional:
 
+- **agent** (Boolean) Use a local SSH agent to login to the remote host. Defaults to `false`.
 - **password** (String, Sensitive) The pasword for the user on the remote host.
 - **port** (Number) The ssh port on the remote host. Defaults to `22`.
 - **private_key** (String, Sensitive) The private key used to login to the remote host.
@@ -84,6 +85,7 @@ Optional:
 
 Read-Only:
 
+- **agent** (Boolean)
 - **host** (String)
 - **password** (String)
 - **port** (Number)

--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -118,11 +118,11 @@ func ConnectionFromResourceData(d *schema.ResourceData) (string, *ssh.ClientConf
 
 	enable_agent, ok := d.GetOk("result_conn.0.agent")
 	if ok && enable_agent.(bool) {
-		sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
+		connection, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't connect to SSH agent: %s", err.Error())
 		}
-		clientConfig.Auth = append(clientConfig.Auth, ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers))
+		clientConfig.Auth = append(clientConfig.Auth, ssh.PublicKeysCallback(agent.NewClient(connection).Signers))
 	}
 
 	host := fmt.Sprintf("%s:%d", d.Get("result_conn.0.host").(string), d.Get("result_conn.0.port").(int))

--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -116,7 +116,7 @@ func ConnectionFromResourceData(d *schema.ResourceData) (string, *ssh.ClientConf
 		clientConfig.Auth = append(clientConfig.Auth, ssh.PublicKeys(signer))
 	}
 
-	enable_agent, ok := d.GetOk("result_conn.0.agent")
+	enableAgent, ok := d.GetOk("result_conn.0.agent")
 	if ok && enable_agent.(bool) {
 		connection, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 		if err != nil {

--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -117,7 +117,7 @@ func ConnectionFromResourceData(d *schema.ResourceData) (string, *ssh.ClientConf
 	}
 
 	enableAgent, ok := d.GetOk("result_conn.0.agent")
-	if ok && enable_agent.(bool) {
+	if ok && enableAgent.(bool) {
 		connection, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't connect to SSH agent: %s", err.Error())


### PR DESCRIPTION
Hi & thanks a lot for this project!

Here's a minimal implementation which allows connecting via a local SSH agent, which can be useful if the private key is either password protected or not available because it's stored on a hardware token (as is the case with my yubikey).
Is this something you would merge?

Additionally, would you welcome a breaking change in another PR which synchronizes the parameters of this providers `conn` blocks with modern terraforms `connection` blocks?

