### PR TITLE
Allow simple use of `keyboard-interactive` authentication

### DIFF
--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -89,6 +89,17 @@ func ConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (st
 	password, ok := d.GetOk("conn.0.password")
 	if ok {
 		clientConfig.Auth = append(clientConfig.Auth, ssh.Password(password.(string)))
+
+		// An implementation of ssh.KeyboardInteractiveChallenge that simply sends back the password for all questions.
+		cb := func(user, instruction string, questions []string, echos []bool) ([]string, error) {
+			answers := make([]string, len(questions))
+			for i := range answers {
+				answers[i] = password.(string)
+			}
+
+			return answers, nil
+		}
+		clientConfig.Auth = append(clientConfig.Auth, ssh.KeyboardInteractive(cb))
 	}
 
 	private_key, ok := d.GetOk("conn.0.private_key")


### PR DESCRIPTION
I am trying to use `remote_file` with an SSH server configured with:

```
PasswordAuthentication no
ChallengeResponseAuthentication yes
UsePAM yes
```

The challenge-response authentication is a simple password prompt, which is equivalent to `PasswordAuthentication`. 