### PR TITLE
ci: write permission on docker build/push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,8 @@ jobs:
     name: Build remote host image
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3.5.3


### PR DESCRIPTION
Might not fix dependabot failing to push docker image, but worth a shot