### PR TITLE
chore: fix deprecated goreleaser changelog.skip

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,4 +59,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
> Changed to disable to conform with all other pipes.

https://goreleaser.com/deprecations/#__tabbed_6_2