### PR TITLE
Add support for encrypted private keys

### DIFF
--- a/docs/data-sources/file.md
+++ b/docs/data-sources/file.md
@@ -73,6 +73,7 @@ Optional:
 - `port` (Number) The ssh port on the remote host. Defaults to `22`.
 - `private_key` (String, Sensitive) The private key used to login to the remote host.
 - `private_key_env_var` (String) The name of the local environment variable containing the private key used to login to the remote host.
+- `private_key_pass` (String, Sensitive) Passphrase for the encrypted private key.
 - `private_key_path` (String) The local path to the private key used to login to the remote host.
 - `sudo` (Boolean) Use sudo to gain access to file. Defaults to `false`.
 - `timeout` (Number) The maximum amount of time, in milliseconds, for the TCP connection to establish. Timeout of zero means no timeout.

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ Optional:
 - `port` (Number) The ssh port on the remote host. Defaults to `22`.
 - `private_key` (String, Sensitive) The private key used to login to the remote host.
 - `private_key_env_var` (String) The name of the local environment variable containing the private key used to login to the remote host.
+- `private_key_pass` (String, Sensitive) Passphrase for the encrypted private key.
 - `private_key_path` (String) The local path to the private key used to login to the remote host.
 - `sudo` (Boolean) Use sudo to gain access to file. Defaults to `false`.
 - `timeout` (Number) The maximum amount of time, in milliseconds, for the TCP connection to establish. Timeout of zero means no timeout.

--- a/docs/resources/file.md
+++ b/docs/resources/file.md
@@ -83,6 +83,7 @@ Optional:
 - `port` (Number) The ssh port on the remote host. Defaults to `22`.
 - `private_key` (String, Sensitive) The private key used to login to the remote host.
 - `private_key_env_var` (String) The name of the local environment variable containing the private key used to login to the remote host.
+- `private_key_pass` (String, Sensitive) Passphrase for the encrypted private key.
 - `private_key_path` (String) The local path to the private key used to login to the remote host.
 - `sudo` (Boolean) Use sudo to gain access to file. Defaults to `false`.
 - `timeout` (Number) The maximum amount of time, in milliseconds, for the TCP connection to establish. Timeout of zero means no timeout.

--- a/internal/provider/connection.go
+++ b/internal/provider/connection.go
@@ -61,6 +61,12 @@ var connectionSchemaResource = &schema.Resource{
 			Sensitive:   true,
 			Description: "The private key used to login to the remote host.",
 		},
+		"private_key_pass": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Sensitive:   true,
+			Description: "Passphrase for the encrypted private key.",
+		},
 		"private_key_path": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -112,7 +118,7 @@ func ConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (st
 			return "", nil, err
 		}
 
-		signer, err := ssh.ParsePrivateKey([]byte(privateKey))
+		signer, err := parsePrivateKey(d, privateKey)
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't create a ssh client config from private key: %s", err.Error())
 		}
@@ -128,7 +134,7 @@ func ConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (st
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't read private key: %s", err.Error())
 		}
-		signer, err := ssh.ParsePrivateKey(content)
+		signer, err := parsePrivateKey(d, string(content))
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't create a ssh client config from private key file: %s", err.Error())
 		}
@@ -140,8 +146,8 @@ func ConnectionFromResourceData(ctx context.Context, d *schema.ResourceData) (st
 			return "", nil, err
 		}
 
-		content := []byte(os.Getenv(privateKeyEnvVar))
-		signer, err := ssh.ParsePrivateKey(content)
+		content := os.Getenv(privateKeyEnvVar)
+		signer, err := parsePrivateKey(d, content)
 		if err != nil {
 			return "", nil, fmt.Errorf("couldn't create a ssh client config from private key env var: %s", err.Error())
 		}


### PR DESCRIPTION
Our private keys are encrypted. You need a password for unlock it.
This patch add a helper function for handle key password, and drop error if try use encrypted key without password.