### PR TITLE
Use current repository for test image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           context: tests
           push: true
-          tags: ghcr.io/tenstad/remotehost:${{ github.sha }}
+          tags: ghcr.io/${{ github.repository }}:test-${{ github.sha }}
 
   # run acceptance tests in a matrix with Terraform core versions
   test:
@@ -103,9 +103,9 @@ jobs:
           - 1.1.*
     services:
       remotehost:
-        image: ghcr.io/tenstad/remotehost:${{ github.sha }}
+        image: ghcr.io/${{ github.repository }}:test-${{ github.sha }}
       remotehost2:
-        image: ghcr.io/tenstad/remotehost:${{ github.sha }}
+        image: ghcr.io/${{ github.repository }}:test-${{ github.sha }}
     container:
       image: golang:1.24
     steps:


### PR DESCRIPTION
Fork tests are broken, becase test image name is hardcoded to your name, and we havent write permission.

This patch change the image name to owner repository, with own image tag prefix.