### PR TITLE
Store the content hash in state file

### DIFF
--- a/internal/provider/move_file_test.go
+++ b/internal/provider/move_file_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"os"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -54,8 +53,8 @@ func TestMovingFileByModifyingProvider(t *testing.T) {
 				}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"data.remote_file.move_file", "content", regexp.MustCompile("x")),
+					resource.TestCheckResourceAttr(
+						"data.remote_file.move_file", "content", hashString("x")),
 				),
 			},
 		},
@@ -119,8 +118,10 @@ func TestMovingFileByModifyingConn(t *testing.T) {
 				}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"data.remote_file.move_file_2", "content", regexp.MustCompile("x")),
+					resource.TestCheckResourceAttr(
+						"remote_file.move_file_2", "content", hashString("x")),
+					resource.TestCheckResourceAttr(
+						"data.remote_file.move_file_2", "content", "x"),
 				),
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strconv"
@@ -231,4 +233,15 @@ func resourceConnectionHash(d *schema.ResourceData) (string, error) {
 		strconv.FormatBool(agent),
 	}
 	return strings.Join(elements, "::"), nil
+}
+
+// hashString returns a hash of the input for use as a StateFunc
+func hashString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		hash := sha1.Sum([]byte(val)) // nolint: gosec
+		return hex.EncodeToString(hash[:])
+	default:
+		return ""
+	}
 }

--- a/internal/provider/resource_remote_file.go
+++ b/internal/provider/resource_remote_file.go
@@ -35,6 +35,7 @@ func resourceRemoteFile() *schema.Resource {
 				Description: "Content of file.",
 				Type:        schema.TypeString,
 				Required:    true,
+				StateFunc:   hashString,
 			},
 			"permissions": {
 				Description: "Permissions of file (in octal form).",
@@ -218,7 +219,7 @@ func resourceRemoteFileRead(ctx context.Context, d *schema.ResourceData, meta in
 		if err != nil {
 			return diag.Errorf("unable to read remote file: %s", err.Error())
 		}
-		if err := d.Set("content", content); err != nil {
+		if err := d.Set("content", hashString(content)); err != nil {
 			return diag.FromErr(err)
 		}
 

--- a/internal/provider/resource_remote_file_test.go
+++ b/internal/provider/resource_remote_file_test.go
@@ -29,8 +29,8 @@ func TestAccResourceRemoteFile(t *testing.T) {
 				}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"remote_file.resource_1", "content", regexp.MustCompile("resource_1")),
+					resource.TestCheckResourceAttr(
+						"remote_file.resource_1", "content", hashString("resource_1")),
 				),
 			},
 		},
@@ -54,8 +54,8 @@ func TestAccResourceRemoteFileWithDefaultConnection(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"remote_file.resource_2", "id", regexp.MustCompile("remotehost:22:/tmp/resource_2.txt")),
-					resource.TestMatchResourceAttr(
-						"remote_file.resource_2", "content", regexp.MustCompile("resource_2")),
+					resource.TestCheckResourceAttr(
+						"remote_file.resource_2", "content", hashString("resource_2")),
 				),
 			},
 		},
@@ -84,8 +84,8 @@ func TestAccResourceRemoteFileWithAgent(t *testing.T) {
 				}
 				`,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr(
-						"remote_file.resource_3", "content", regexp.MustCompile("resource_3")),
+					resource.TestCheckResourceAttr(
+						"remote_file.resource_3", "content", hashString("resource_3")),
 				),
 			},
 		},


### PR DESCRIPTION
Upload with remote_file resource, the whole content is in state file.

If you upload large file, the state file will be large too (contains the content).
This patch change this, store the content hash in state file
